### PR TITLE
FACT-284: display 'divorce' area of law as 'divorce hearings' for in …

### DIFF
--- a/src/main/locales/cy/court-details.json
+++ b/src/main/locales/cy/court-details.json
@@ -44,5 +44,6 @@
   "processingTimes": "Amseroedd prosesu neu ateb",
   "sendUsYourDocuments": "Anfonwch eich dogfennau atom",
   "updates": "Cael diweddariad gyda'ch cais",
-  "altImageText": "Tu blaen"
+  "altImageText": "Tu blaen",
+  "divorceHearings": "Divorce hearings"
 }

--- a/src/main/locales/en/court-details.json
+++ b/src/main/locales/en/court-details.json
@@ -44,5 +44,6 @@
   "processingTimes": "Processing or reply times",
   "sendUsYourDocuments": "Send us your documents",
   "updates": "Get an update with your application",
-  "altImageText": "Front view of"
+  "altImageText": "Front view of",
+  "divorceHearings": "Divorce hearings"
 }

--- a/src/main/views/court-details/in-person-court.njk
+++ b/src/main/views/court-details/in-person-court.njk
@@ -191,16 +191,18 @@
           </h3>
           <ul class="govuk-list">
             {% for area in results['areas_of_law'] | sort(attribute="name") %}
-            {% if area['display_name'] %}
-            {% set displayName = area['display_name'] %}
-            {% else %}
-            {% set displayName = area.name %}
-            {% endif %}
-            {% if area['display_external_link'] %}
-            {% set externalLink = area['display_external_link'] %}
-            {% else %}
-            {% set externalLink = area['external_link'] %}
-            {% endif %}
+              {% if area.name === 'Divorce' %}
+                {% set displayName = divorceHearings %}
+              {% elseif area['display_name'] %}
+                {% set displayName = area['display_name'] %}
+              {% else %}
+                {% set displayName = area.name %}
+              {% endif %}
+              {% if area['display_external_link'] %}
+                {% set externalLink = area['display_external_link'] %}
+              {% else %}
+                {% set externalLink = area['external_link'] %}
+              {% endif %}
               <li>
                 {% if externalLink %}
                   <a class="govuk-link" href="{{ externalLink }}">{{ displayName }}</a>


### PR DESCRIPTION
### JIRA link ###
https://tools.hmcts.net/jira/browse/FACT-284


### Change description ###
Display 'divorce' area of law as 'divorce hearings' for in person courts

