### PR TITLE
FACT-357 - Updated P1 text on not-in-person courts to use area of law instead of service area

### DIFF
--- a/src/main/controllers/CourtDetailsController.ts
+++ b/src/main/controllers/CourtDetailsController.ts
@@ -1,7 +1,7 @@
 import { FactRequest } from '../interfaces/FactRequest';
 import { NextFunction, Response } from 'express';
 import { FactApi } from '../utils/FactApi';
-import { decideCatchmentArea, filterByDescription, formatServiceAreas } from '../utils/CourtDetailsUtils';
+import { decideCatchmentArea, filterByDescription, formatAreasOfLaw } from '../utils/CourtDetailsUtils';
 import { isEmpty, isObjectEmpty } from '../utils/validation';
 import autobind from 'autobind-decorator';
 import { Enquiries } from '../interfaces/Enquiries';
@@ -54,7 +54,7 @@ export class CourtDetailsController {
           } else {
             viewData.notInPersonP1 = viewData.notInPersonP1
               .replace('{catchmentArea}', decideCatchmentArea(this.regionalCentre, viewData.catchmentArea))
-              .replace('{serviceArea}', formatServiceAreas(courtDetails['service_area']));
+              .replace('{serviceArea}', formatAreasOfLaw(courtDetails['areas_of_law']));
 
             return res.render('court-details/not-in-person-court', viewData);
           }

--- a/src/main/utils/CourtDetailsUtils.ts
+++ b/src/main/utils/CourtDetailsUtils.ts
@@ -1,20 +1,22 @@
-import { isArrayEmpty } from './validation';
-
 export const decideCatchmentArea = (regionalCentre: boolean, area: { area1: string; area2: string }): string => {
   return regionalCentre ? area.area1 : area.area2;
 };
 
-export const formatServiceAreas = (serviceAreas: string[]): string => {
-  if(isArrayEmpty(serviceAreas)) {
-    return '';
-  }
+export const formatAreasOfLaw = (areasOfLaw: any[]): string => {
+  let output = '';
 
-  const lastElement: string = serviceAreas.pop();
-  let serviceAreaString: string = serviceAreas.join(', ');
-  serviceAreaString += serviceAreas.length >= 1 ? ' and ' : '';
-  serviceAreaString += lastElement;
+  areasOfLaw.forEach((areaOfLaw: any, index) => {
+    const { name, 'display_name': displayName } = areaOfLaw;
+    output += displayName !== null ? displayName : name;
 
-  return serviceAreaString.toLowerCase();
+    if(areasOfLaw.length-1 - index > 1) {
+      output += ', ';
+    } else if (areasOfLaw.length-1 - index === 1) {
+      output += ' and ';
+    }
+  });
+
+  return output.toLowerCase();
 };
 
 export const filterByDescription = (contacts: any[], filter: string[]): any[] => {

--- a/src/test/unit/test/utils/CourtDetailsUtils.ts
+++ b/src/test/unit/test/utils/CourtDetailsUtils.ts
@@ -1,4 +1,4 @@
-import {decideCatchmentArea, formatServiceAreas} from '../../../../main/utils/CourtDetailsUtils';
+import {decideCatchmentArea, formatAreasOfLaw} from '../../../../main/utils/CourtDetailsUtils';
 
 describe('CourtDetailsUtils', () => {
   describe('decideCatchmentArea', () => {
@@ -23,27 +23,36 @@ describe('CourtDetailsUtils', () => {
 
   describe('formatServiceAreas', () => {
     test('Should return single formatted area', () => {
-      const serviceAreas: string[] = ['Money'];
+      const areasOfLaw: any = [
+        {name: 'Money', 'display_name': null}
+      ];
 
-      expect(formatServiceAreas(serviceAreas)).toEqual('money');
+      expect(formatAreasOfLaw(areasOfLaw)).toEqual('money');
     });
 
     test('Should return dual formatted areas', () => {
-      const serviceAreas: string[] = ['Money', 'Civil Protection'];
+      const areasOfLaw: any = [
+        {name: 'Money', 'display_name': null},
+        {name: 'Civil Protection', 'display_name': null}
+      ];
 
-      expect(formatServiceAreas(serviceAreas)).toEqual('money and civil protection');
+      expect(formatAreasOfLaw(areasOfLaw)).toEqual('money and civil protection');
     });
 
     test('Should return list of formatted areas', () => {
-      const serviceAreas: string[] = ['Money', 'Civil Protection', 'Divorce'];
+      const areasOfLaw: any = [
+        {name: 'Money', 'display_name': null},
+        {name: 'Civil Protection', 'display_name': null},
+        {name: 'Divorce', 'display_name': null}
+      ];
 
-      expect(formatServiceAreas(serviceAreas)).toEqual('money, civil protection and divorce');
+      expect(formatAreasOfLaw(areasOfLaw)).toEqual('money, civil protection and divorce');
     });
 
     test('Should return empty string', () => {
-      const serviceAreas: string[] = ['Money', 'Civil Protection', 'Divorce'];
+      const areasOfLaw: any = [];
 
-      expect(formatServiceAreas(serviceAreas)).toEqual('money, civil protection and divorce');
+      expect(formatAreasOfLaw(areasOfLaw)).toEqual('');
     });
   });
 });


### PR DESCRIPTION
### JIRA link ###
https://tools.hmcts.net/jira/browse/FACT-357


### Change description ###
Previous implementation used service area which was unset on a number of courts due to logic reasons within the API (see [FACT-373](https://tools.hmcts.net/jira/browse/FACT-373). New implementation makes use of area of law attribute contained with each court instead. Subsequently fixes translation issues within P1 too.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
