### PR TITLE
FACT-412 - Updated cookie manager version

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "cichecks": "yarn && yarn build && yarn lint && yarn test"
   },
   "dependencies": {
-    "@hmcts/fact-cookie-manager": "github:hmcts/fact-cookie-manager#0.0.1",
+    "@hmcts/cookie-manager": "github:hmcts/cookie-manager#0.0.3",
     "@hmcts/info-provider": "^1.0.0",
     "@hmcts/nodejs-healthcheck": "^1.7.0",
     "@hmcts/nodejs-logging": "^3.0.1",

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -1,8 +1,8 @@
 import './assets/scss/main.scss';
 import {initAll} from 'govuk-frontend';
 
-const cookieManager = require('../../node_modules/@hmcts/fact-cookie-manager/cookie-manager.js');
-const cookieBanner = document.querySelector('#cookie_banner');
+const cookieManager = require('@hmcts/cookie-manager');
+const cookieBanner = document.querySelector('#cm-cookie-banner');
 const cookieBannerDecision = cookieBanner.querySelector('.govuk-cookie-banner__decision');
 const cookieBannerConfirmation = cookieBanner.querySelector('.govuk-cookie-banner__confirmation');
 
@@ -16,19 +16,16 @@ function cookieBannerReject() {
   confirmationMessage.innerHTML = 'You’ve rejected analytics cookies. ' + confirmationMessage.innerHTML;
 }
 
-function cookieBannerSaved(cookieStatus) {
+function cookieBannerSaved() {
   cookieBannerDecision.hidden = true;
   cookieBannerConfirmation.hidden = false;
-  cookiePreferencesUpdated(cookieStatus);
 }
 
-function preferenceFormSaved(cookieStatus) {
+function preferenceFormSaved() {
   const message = document.querySelector('.cookie-preference-success');
   message.style.display = 'block';
   document.body.scrollTop = 0; // For Safari
   document.documentElement.scrollTop = 0; // For Chrome, Firefox, IE and Opera
-
-  cookiePreferencesUpdated(cookieStatus);
 }
 
 function cookiePreferencesUpdated(cookieStatus) {
@@ -44,15 +41,16 @@ function cookiePreferencesUpdated(cookieStatus) {
 }
 
 cookieManager.init({
-  'cookie-banner-id': 'cookie_banner',
-  'cookie-banner-visible-on-page-with-preference-form': false,
   'user-preference-cookie-name': 'fact-cookie-preferences',
-  'user-preference-configuration-form-id': 'cm_user_preference_form',
-  'user-preference-saved-callback': preferenceFormSaved,
+  'user-preference-saved-callback': cookiePreferencesUpdated,
+  'preference-form-id': 'cm-preference-form',
+  'preference-form-saved-callback': preferenceFormSaved,
+  'set-checkboxes-in-preference-form': true,
+  'cookie-banner-id': 'cm-cookie-banner',
+  'cookie-banner-visible-on-page-with-preference-form': false,
   'cookie-banner-reject-callback': cookieBannerReject,
   'cookie-banner-accept-callback': cookieBannerAccept,
   'cookie-banner-saved-callback': cookieBannerSaved,
-  'set-checkboxes-in-preference-form': true,
   'cookie-banner-auto-hide': false,
   'cookie-manifest': [
     {

--- a/src/main/views/cookies.njk
+++ b/src/main/views/cookies.njk
@@ -163,7 +163,7 @@
     ]
   }) }}
 
-  <form id="cm_user_preference_form" class="js-show">
+  <form id="cm-preference-form" class="js-show">
     {{ govukRadios({
       classes: 'govuk-radios',
       idPrefix: 'analytics',

--- a/src/main/views/template.njk
+++ b/src/main/views/template.njk
@@ -39,7 +39,7 @@
       <p>You can <a href="/cookies">change your cookie settings</a> at any time.</p>
     {% endset %}
 
-    <div class="global-cookie-message" id="cookie_banner" hidden>
+    <div class="global-cookie-message" id="cm-cookie-banner" hidden>
       {{ govukCookieBanner({
         ariaLabel: cookieBannerH1,
         messages: [

--- a/src/main/views/webpack/js.njk
+++ b/src/main/views/webpack/js.njk
@@ -1,1 +1,1 @@
-<script src="/main.60a44dbb4f5136528e03.js"></script>
+<script src="/main.0953e3eabc4caadee515.js"></script>

--- a/yarn.lock
+++ b/yarn.lock
@@ -863,9 +863,9 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@hmcts/fact-cookie-manager@github:hmcts/fact-cookie-manager#0.0.1":
-  version "1.0.0"
-  resolved "https://codeload.github.com/hmcts/fact-cookie-manager/tar.gz/f879717593928cda2b094084a123c9f9af2860d4"
+"@hmcts/cookie-manager@github:hmcts/cookie-manager#0.0.3":
+  version "0.0.3"
+  resolved "https://codeload.github.com/hmcts/cookie-manager/tar.gz/f2ac27c8e2754a0917d76b7f337477cfa8ed1164"
 
 "@hmcts/info-provider@^1.0.0":
   version "1.0.0"


### PR DESCRIPTION
### JIRA link ###
https://tools.hmcts.net/jira/browse/FACT-412

### Change description ###
- Updated cookie manager version and repo to 0.0.3
- Updated cookie banner ID and cookie preference form ID
- Adjusting cookie manager config file to work with revised option names (in 0.0.3 release)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
