### PR TITLE
ga-patch - Fix for using GTAG (GA4) implementation for disabling GA rather than UA implementation.

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -30,15 +30,14 @@ function preferenceFormSaved() {
 
 function cookiePreferencesUpdated(cookieStatus) {
   const dataLayer = window.dataLayer || [];
-  const gtag = window.gtag || function () { dataLayer.push(arguments); };
   const dtrum = window.dtrum;
 
   dataLayer.push({'event': 'cookies', 'preferences': cookieStatus});
 
   if(cookieStatus.analytics === 'on') {
-    gtag('consent', 'update', { 'analytics_storage': 'granted' });
+    window['ga-disable-UA-37377084-66'] = false;
   } else {
-    gtag('consent', 'update', { 'analytics_storage': 'denied' });
+    window['ga-disable-UA-37377084-66'] = true;
   }
 
   if(dtrum !== undefined) {

--- a/src/main/views/template.njk
+++ b/src/main/views/template.njk
@@ -11,24 +11,27 @@
   {% include "webpack/css.njk" %}
   <script>
     dataLayer = window.dataLayer || [];
-    dataLayer.push({"language": "{{ language }}", "event": "Site language"})
+    dataLayer.push({"language": {{ language | dump | safe }}, "event": "Site language"})
 
-    function gtag () {
-      dataLayer.push(arguments);
+    let match = document.cookie.match(new RegExp('(^| )' + 'fact-cookie-preferences' + '=([^;]+)'));
+    if (match && JSON.parse(decodeURIComponent(match[2])).analytics === 'on')
+    {
+      window['ga-disable-UA-37377084-66'] = false;
+    } else {
+      window['ga-disable-UA-37377084-66'] = true;
     }
-
-    gtag('consent', 'default', {'analytics_storage': 'denied'});
   </script>
 
   <meta name="google-site-verification" content="3glfkE1sBXj7EtEdO0ktOm5kyR9E14kR7yw_yJ6GH4U" />
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push(
-  {'gtm.start': new Date().getTime(),event:'gtm.js'}
+    {'gtm.start': new Date().getTime(),event:'gtm.js'}
 
-  );var f=d.getElementsByTagName(s)[0],
-  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-  })(window,document,'script','dataLayer','GTM-N7NMJDR');</script>
+    );var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-N7NMJDR');
+  </script>
 
     {% set html %}
       <p class="govuk-body">{{ cookieBannerP1 | safe }}</p>

--- a/src/main/views/webpack/js.njk
+++ b/src/main/views/webpack/js.njk
@@ -1,1 +1,1 @@
-<script src="/main.7e3889e88776a579494a.js"></script>
+<script src="/main.6efed81404de80540203.js"></script>


### PR DESCRIPTION
### Change description ###
GA on site currently utilises gtag.js method for disabling Google Analytics cookies.
Updated the implementation to use the correct way of accept/denying consent, fixing error message in GTM.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
