### PR TITLE
GA/GTM Fix - Changed data pushed to datalayer and GA consent implementation

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -32,13 +32,7 @@ function cookiePreferencesUpdated(cookieStatus) {
   const dataLayer = window.dataLayer || [];
   const dtrum = window.dtrum;
 
-  dataLayer.push({'event': 'cookies', 'preferences': cookieStatus});
-
-  if(cookieStatus.analytics === 'on') {
-    window['ga-disable-UA-37377084-66'] = false;
-  } else {
-    window['ga-disable-UA-37377084-66'] = true;
-  }
+  dataLayer.push({'event': 'Cookie Preferences', 'cookiePreferences': cookieStatus});
 
   if(dtrum !== undefined) {
     if(cookieStatus.apm === 'on') {

--- a/src/main/views/template.njk
+++ b/src/main/views/template.njk
@@ -13,12 +13,10 @@
     dataLayer = window.dataLayer || [];
     dataLayer.push({"language": {{ language | dump | safe }}, "event": "Site language"})
 
-    let match = document.cookie.match(new RegExp('(^| )' + 'fact-cookie-preferences' + '=([^;]+)'));
-    if (match && JSON.parse(decodeURIComponent(match[2])).analytics === 'on')
-    {
-      window['ga-disable-UA-37377084-66'] = false;
-    } else {
-      window['ga-disable-UA-37377084-66'] = true;
+    const factCookie = document.cookie.match(new RegExp('(^| )' + 'fact-cookie-preferences' + '=([^;]+)'));
+    if(factCookie) {
+      const cookiePreferences = JSON.parse(decodeURIComponent(factCookie[2]));
+      dataLayer.push({'event': 'Cookie Preferences', 'cookiePreferences': cookiePreferences});
     }
   </script>
 

--- a/src/main/views/webpack/js.njk
+++ b/src/main/views/webpack/js.njk
@@ -1,1 +1,1 @@
-<script src="/main.6efed81404de80540203.js"></script>
+<script src="/main.d98cae46c54f545b171d.js"></script>


### PR DESCRIPTION
### Change description ###

- Removed need for setting global/window variable for enabling/disabling GA script. GTM changes mean that GA script will now not be inserted until consent has been provided by the user. This is more in line with what is required of GDPR / DPA


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
