### PR TITLE
Remove logic to retrieve additional links based on sidebar location

### DIFF
--- a/src/main/controllers/CourtDetailsController.ts
+++ b/src/main/controllers/CourtDetailsController.ts
@@ -3,7 +3,6 @@ import { NextFunction, Response } from 'express';
 import { FactApi } from '../utils/FactApi';
 import {
   decideCatchmentArea,
-  filterAdditionalLinks,
   filterByDescription,
   formatAreasOfLaw
 } from '../utils/CourtDetailsUtils';
@@ -14,8 +13,6 @@ import { CourtDetailsData, CourtDetailsResult } from '../interfaces/CourtDetails
 import config from 'config';
 import { cloneDeep } from 'lodash';
 import { generatePlaceMetadata } from '../utils/SEOMetadata';
-import { SidebarLocation } from '../utils/SidebarLocation';
-
 @autobind
 export class CourtDetailsController {
 
@@ -53,16 +50,7 @@ export class CourtDetailsController {
 
           viewData.seoMetadata = generatePlaceMetadata(courtDetails);
           viewData.seoMetadataDescription = (viewData.seoMetadataDescription as string).replace('{courtName}', courtDetails.name);
-
-          if (courtDetails.additional_links.length > 0) {
-            const additionalLinks = {
-              thisLocationHandles: filterAdditionalLinks(courtDetails.additional_links, SidebarLocation.ThisLocationHandles),
-              findOutMoreAbout: filterAdditionalLinks(courtDetails.additional_links, SidebarLocation.FindOutMoreAbout)
-            };
-            viewData.results = {...courtDetails, enquiries, additionalLinks};
-          } else {
-            viewData.results = {...courtDetails, enquiries};
-          }
+          viewData.results = {...courtDetails, enquiries};
 
           if (courtDetails['in_person']) {
             return res.render('court-details/in-person-court', viewData);

--- a/src/main/locales/cy/court-details.json
+++ b/src/main/locales/cy/court-details.json
@@ -45,7 +45,6 @@
   "sendUsYourDocuments": "Anfonwch eich dogfennau atom",
   "updates": "Cael diweddariad gyda'ch cais",
   "altImageText": "Tu blaen",
-  "divorceHearings": "Gwrandawiadau ysgaru",
   "seoMetadataDescription": "{courtName} - Dod o hyd i fanylion cyswllt, oriau agor, sut i deithio yma, mathau o achosion sy'n cael eu rheoli, mynediad i'r adeilad i bobl anabl",
   "getAnUpdateOnYourApplication": "Cael diweddariad gyda'ch cais"
 }

--- a/src/main/locales/en/court-details.json
+++ b/src/main/locales/en/court-details.json
@@ -45,7 +45,6 @@
   "sendUsYourDocuments": "Send us your documents",
   "updates": "Get an update with your application",
   "altImageText": "Front view of",
-  "divorceHearings": "Divorce hearings",
   "seoMetadataDescription": "{courtName} - Find contact details, opening times, how to get to here, types of cases managed, disabled access to the building",
   "getAnUpdateOnYourApplication": "Get an update on your application"
 }

--- a/src/main/utils/CourtDetailsUtils.ts
+++ b/src/main/utils/CourtDetailsUtils.ts
@@ -1,5 +1,3 @@
-import {AdditionalLink} from '../interfaces/CourtDetailsData';
-
 export const decideCatchmentArea = (regionalCentre: boolean, area: { area1: string; area2: string }): string => {
   return regionalCentre ? area.area1 : area.area2;
 };
@@ -23,8 +21,4 @@ export const formatAreasOfLaw = (areasOfLaw: any[]): string => {
 
 export const filterByDescription = (contacts: any[], filter: string[]): any[] => {
   return contacts.filter((contact) => filter.includes(contact.description.toLowerCase()));
-};
-
-export const filterAdditionalLinks = (additionalLinks: AdditionalLink[], sidebarLocation: string): AdditionalLink[] => {
-  return additionalLinks.filter(link => link.location === sidebarLocation);
 };

--- a/src/main/utils/SidebarLocation.ts
+++ b/src/main/utils/SidebarLocation.ts
@@ -1,4 +1,0 @@
-export enum SidebarLocation {
-  ThisLocationHandles = 'This location handles',
-  FindOutMoreAbout = 'Find out more about'
-}

--- a/src/main/views/court-details/in-person-court.njk
+++ b/src/main/views/court-details/in-person-court.njk
@@ -209,9 +209,7 @@
           </h3>
           <ul class="govuk-list">
             {% for area in results['areas_of_law'] | sort(attribute="name") %}
-              {% if area.name === 'Divorce' %}
-                {% set displayName = divorceHearings %}
-              {% elseif area['display_name'] %}
+              {% if area['display_name'] %}
                 {% set displayName = area['display_name'] %}
               {% else %}
                 {% set displayName = area.name %}
@@ -229,23 +227,17 @@
                 {% endif %}
               </li>
             {% endfor %}
-
-            {% for additionalLink in results.additionalLinks.thisLocationHandles %}
-              <li>
-                <a class="govuk-link" href="{{ additionalLink.url }}">{{ additionalLink.description }}</a>
-              </li>
-            {% endfor %}
           </ul>
         </div>
       {% endif %}
 
-      {% if results.additionalLinks.findOutMoreAbout and results.additionalLinks.findOutMoreAbout.length %}
+      {% if results.additional_links and results.additional_links.length %}
         <div class="govuk-grid-row" id="find-out-more-about">
           <h3 class="govuk-heading-m">
             {{ findOutMoreAboutHeading }}:
           </h3>
           <ul class="govuk-list">
-            {% for additionalLink in results.additionalLinks.findOutMoreAbout %}
+            {% for additionalLink in results.additional_links %}
               <li>
                 <a class="govuk-link" href="{{ additionalLink.url }}">{{ additionalLink.description }}</a>
               </li>

--- a/src/main/views/court-details/not-in-person-court.njk
+++ b/src/main/views/court-details/not-in-person-court.njk
@@ -178,7 +178,7 @@
       </div>
 
       <div class="govuk-grid-column-one-third side-content">
-        {% if (results['areas_of_law'] and results['areas_of_law'] |  selectattr("external_link") | length > 0) or (results.additionalLinks.findOutMoreAbout and results.additionalLinks.findOutMoreAbout.length) %}
+        {% if results['areas_of_law'] and results['areas_of_law'] |  selectattr("external_link") | length > 0 %}
           <div class="govuk-grid-row" id="areas-of-law">
             <h3 class="govuk-heading-m">
               {{ findOutMoreAboutHeading }}:
@@ -199,12 +199,6 @@
                   {% if externalLink %}
                     <a class="govuk-link" href="{{ externalLink }}">{{ displayName }}</a>
                   {% endif %}
-                </li>
-              {% endfor %}
-
-              {% for additionalLink in results.additionalLinks.findOutMoreAbout %}
-                <li>
-                  <a class="govuk-link" href="{{ additionalLink.url }}">{{ additionalLink.description }}</a>
                 </li>
               {% endfor %}
             </ul>

--- a/src/test/functional/features/court-details.feature
+++ b/src/test/functional/features/court-details.feature
@@ -280,4 +280,4 @@ Feature: Court Name Know - Court Details
 
     Examples:
       | in_person_court                            | sidebar_entries       | page_title                                                | page_link           | index  |
-      | Birmingham Civil and Family Justice Centre | areas-of-law          | Money and property when you divorce or separate - GOV.UK  | Financial Remedy    | 14     |
+      | Birmingham Civil and Family Justice Centre | areas-of-law          | Money and property when you divorce or separate - GOV.UK  | Financial Remedy    | 9     |

--- a/src/test/unit/test/controllers/CourtDetailsController.ts
+++ b/src/test/unit/test/controllers/CourtDetailsController.ts
@@ -45,22 +45,6 @@ describe('CourtDetailsController', () => {
           fax: [],
           phone: [],
           welshPhone: []
-        },
-        additionalLinks: {
-          thisLocationHandles: [
-            {
-              url: 'https://www.gov.uk/money-property-when-relationship-ends',
-              description: 'Financial Remedy',
-              location: 'This location handles'
-            }
-          ],
-          findOutMoreAbout: [
-            {
-              url: 'https://www.supportthroughcourt.org',
-              description: 'Support Through Court (Independent charity)',
-              location: 'Find out more about',
-            }
-          ]
         }
       },
       seoMetadata: {
@@ -104,22 +88,6 @@ describe('CourtDetailsController', () => {
           fax: [],
           phone: [],
           welshPhone: []
-        },
-        additionalLinks: {
-          thisLocationHandles: [
-            {
-              url: 'https://www.gov.uk/money-property-when-relationship-ends',
-              description: 'Financial Remedy',
-              location: 'This location handles'
-            }
-          ],
-          findOutMoreAbout: [
-            {
-              url: 'https://www.supportthroughcourt.org',
-              description: 'Support Through Court (Independent charity)',
-              location: 'Find out more about',
-            }
-          ]
         }
       },
       seoMetadata: {

--- a/src/test/unit/test/utils/CourtDetailsUtils.ts
+++ b/src/test/unit/test/utils/CourtDetailsUtils.ts
@@ -1,9 +1,7 @@
 import {
-  filterAdditionalLinks,
   decideCatchmentArea,
   formatAreasOfLaw
 } from '../../../../main/utils/CourtDetailsUtils';
-import {AdditionalLink} from '../../../../main/interfaces/CourtDetailsData';
 
 describe('CourtDetailsUtils', () => {
   describe('decideCatchmentArea', () => {
@@ -58,40 +56,6 @@ describe('CourtDetailsUtils', () => {
       const areasOfLaw: any = [];
 
       expect(formatAreasOfLaw(areasOfLaw)).toEqual('');
-    });
-  });
-
-  describe('filterAdditionalLinks', () => {
-    const url1 = 'www.test1.com';
-    const url2 = 'www.test2.com';
-    const url3 = 'www.test3.com';
-
-    const thisLocationHandles = 'This location handles';
-    const findOutMoreAbout = 'Find out more about';
-
-    test('Should filter additional Links on location', () => {
-      const additionalLinks: AdditionalLink[] = [
-        {
-          url: url1,
-          description: 'description1',
-          location: thisLocationHandles
-        },
-        {
-          url: url2,
-          description: 'description2',
-          location: findOutMoreAbout
-        },
-        {
-          url: url3,
-          description: 'description3',
-          location: thisLocationHandles
-        }
-      ];
-
-      const results: AdditionalLink[] = filterAdditionalLinks(additionalLinks, thisLocationHandles);
-      expect(results.length).toEqual(2);
-      expect(results[0].url).toEqual(url1);
-      expect(results[1].url).toEqual(url3);
     });
   });
 });


### PR DESCRIPTION
### JIRA link ###

https://tools.hmcts.net/jira/browse/FACT-882

### Change description ###

- Remove logic to retrieve additional links based on sidebar location
- Remove hardcoded 'divorce hearings' for in-person courts. Instead, pick this up from the API response

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
