### PR TITLE
FACT-1187 fixed issue with not in person court page

### DIFF
--- a/src/main/views/court-details/not-in-person-court.njk
+++ b/src/main/views/court-details/not-in-person-court.njk
@@ -263,10 +263,10 @@
       </div>
 
       <div class="govuk-grid-column-one-third side-content">
-        {% if results['areas_of_law'] and results['areas_of_law'] |  selectattr("external_link") | length > 0 %}
+        {% if (results['areas_of_law'] and results['areas_of_law'].length > 0) or (results.additionalLinks.findOutMoreAbout and results.additionalLinks.findOutMoreAbout.length) %}
           <div class="govuk-grid-row" id="areas-of-law">
             <h3 class="govuk-heading-m">
-              {{ findOutMoreAboutHeading }}
+              {{ areasOfLawHeading }}
             </h3>
             <ul class="govuk-list">
               {% for area in results['areas_of_law'] | sort(attribute="name") %}
@@ -285,12 +285,21 @@
                     <a class="govuk-link" href="{{ externalLink }}">{{ displayName }}</a>
                   {% else %}
                     <p>
-                       {{displayName}}
+                      {{displayName}}
                     </p>
                   {% endif %}
                 </li>
               {% endfor %}
+            </ul>
+          </div>
+        {% endif %}
 
+        {% if results.additional_links and results.additional_links.length %}
+          <div class="govuk-grid-row" id="find-out-more-about">
+            <h3 class="govuk-heading-m">
+              {{ findOutMoreAboutHeading }}
+            </h3>
+            <ul class="govuk-list">
               {% for additionalLink in results.additional_links %}
                 <li>
                   <a class="govuk-link" href="{{ additionalLink.url }}">{{ additionalLink.description }}</a>


### PR DESCRIPTION
### JIRA link ###
https://tools.hmcts.net/jira/browse/FACT-1187


### Change description ###
bug is when adding 'additional links' and having no 'cases heard' options for not in person pages then the additional links disappear. fixed issue by using same view as in person view nunjucks.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x ] No
```
