### PR TITLE
FACT-2206 - Append warning when link opens in new window

### DIFF
--- a/src/main/modules/nunjucks/index.ts
+++ b/src/main/modules/nunjucks/index.ts
@@ -1,6 +1,7 @@
 import * as path from 'path';
 import * as express from 'express';
 import * as nunjucks from 'nunjucks';
+import createFilters from './njkFilters';
 
 export class Nunjucks {
 
@@ -11,7 +12,7 @@ export class Nunjucks {
 
   enableFor(app: express.Express): void {
     app.set('view engine', 'njk');
-    nunjucks.configure(
+    const env = nunjucks.configure(
       [path.join(__dirname, '..', '..', 'views')],
       {
         autoescape: true,
@@ -31,5 +32,7 @@ export class Nunjucks {
 
       next();
     });
+
+    createFilters(env);
   }
 }

--- a/src/main/modules/nunjucks/njkFilters.ts
+++ b/src/main/modules/nunjucks/njkFilters.ts
@@ -7,7 +7,7 @@ function createFilters(env: nunjucks.Environment): void {
     //tab) to the link text.
     return infoWithLinks.replace(
       /(<a\s+[^>]*target=['"]?(?:_blank|_new)['"]?[^>]*>)(.*?)(<\/a>)/gi, // Match anchor tags with target="_blank"
-      (match: any, openingTag: any, linkText: any, closingTag) => `${openingTag}${linkText} (opens in new tab)${closingTag}`
+      (match: any, openingTag: any, linkText: any, closingTag) => `${openingTag}${linkText}<span class=govuk-visually-hidden> - opens in a new tab</span>${closingTag}`
     );
 
   });

--- a/src/main/modules/nunjucks/njkFilters.ts
+++ b/src/main/modules/nunjucks/njkFilters.ts
@@ -2,6 +2,9 @@ import nunjucks from 'nunjucks';
 
 function createFilters(env: nunjucks.Environment): void {
   env.addFilter('warningAppender', function (infoWithLinks: string) {
+    //This filter expects a string containing links (html anchor tags <a></a>). If the link suggests it would open a new
+    //tab - by containing the target attribute with value _blank or _new - then this filter appends the phrase (opens in
+    //tab to the link text.
     return infoWithLinks.replace(
       /(<a\s+[^>]*target=['"]?(?:_blank|_new)['"]?[^>]*>)(.*?)(<\/a>)/gi, // Match anchor tags with target="_blank"
       (match: any, openingTag: any, linkText: any, closingTag) => `${openingTag}${linkText} (opens in new tab)${closingTag}`

--- a/src/main/modules/nunjucks/njkFilters.ts
+++ b/src/main/modules/nunjucks/njkFilters.ts
@@ -4,7 +4,7 @@ function createFilters(env: nunjucks.Environment): void {
   env.addFilter('warningAppender', function (infoWithLinks: string) {
     //This filter expects a string containing links (html anchor tags <a></a>). If the link suggests it would open a new
     //tab - by containing the target attribute with value _blank or _new - then this filter appends the phrase (opens in
-    //tab to the link text.
+    //tab) to the link text.
     return infoWithLinks.replace(
       /(<a\s+[^>]*target=['"]?(?:_blank|_new)['"]?[^>]*>)(.*?)(<\/a>)/gi, // Match anchor tags with target="_blank"
       (match: any, openingTag: any, linkText: any, closingTag) => `${openingTag}${linkText} (opens in new tab)${closingTag}`

--- a/src/main/modules/nunjucks/njkFilters.ts
+++ b/src/main/modules/nunjucks/njkFilters.ts
@@ -3,8 +3,8 @@ import nunjucks from 'nunjucks';
 function createFilters(env: nunjucks.Environment): void {
   env.addFilter('warningAppender', function (infoWithLinks: string) {
     //This filter expects a string containing links (html anchor tags <a></a>). If the link suggests it would open a new
-    //tab - by containing the target attribute with value _blank or _new - then this filter appends the phrase (opens in
-    //tab) to the link text.
+    //tab - by containing the target attribute with value _blank or _new - then this filter appends the hidden text opens in
+    //tab to the link text.
     return infoWithLinks.replace(
       /(<a\s+[^>]*target=['"]?(?:_blank|_new)['"]?[^>]*>)(.*?)(<\/a>)/gi, // Match anchor tags with target="_blank"
       (match: any, openingTag: any, linkText: any, closingTag) => `${openingTag}${linkText}<span class=govuk-visually-hidden> - opens in a new tab</span>${closingTag}`

--- a/src/main/modules/nunjucks/njkFilters.ts
+++ b/src/main/modules/nunjucks/njkFilters.ts
@@ -1,0 +1,13 @@
+import nunjucks from 'nunjucks';
+
+function createFilters(env: nunjucks.Environment): void {
+  env.addFilter('warningAppender', function (infoWithLinks: string) {
+    return infoWithLinks.replace(
+      /(<a\s+[^>]*target=['"]?(?:_blank|_new)['"]?[^>]*>)(.*?)(<\/a>)/gi, // Match anchor tags with target="_blank"
+      (match: any, openingTag: any, linkText: any, closingTag) => `${openingTag}${linkText} (opens in new tab)${closingTag}`
+    );
+
+  });
+}
+
+export default createFilters;

--- a/src/main/views/court-details/in-person-court.njk
+++ b/src/main/views/court-details/in-person-court.njk
@@ -139,7 +139,7 @@
             {{ additionalInfoHeading }}
           </h3>
           <div class="govuk-body-m">
-            {{ results.info | safe }}
+            {{ results.info | warningAppender | safe }}
           </div>
         </div>
       {% endif %}

--- a/src/main/views/court-details/not-in-person-court.njk
+++ b/src/main/views/court-details/not-in-person-court.njk
@@ -139,7 +139,7 @@
               {{ additionalInfoHeading }}
             </h3>
             <div class="govuk-body-m">
-              {{ results.info | safe }}
+              {{ results.info | warningAppender | safe }}
             </div>
           </div>
         {% endif %}

--- a/src/test/unit/test/modules/nunjucks/njkFilters.ts
+++ b/src/test/unit/test/modules/nunjucks/njkFilters.ts
@@ -10,37 +10,37 @@ describe('njkFilters', () => {
     createFilters(env);
   });
 
-  describe('Test the filter that appends warning to links that open new tabs', () => {
-    test('should add (opens new tab) text to link that contains target="_blank"', () => {
+  describe('Test the filter that appends a hidden warning to links that open new tabs', () => {
+    test('should add hidden "opens in a new tab" text to link that contains target="_blank"', () => {
       const warningAppenderFilter = env.getFilter('warningAppender');
       const input = '<a href="https://www.gov.uk/government/news/scammers-using-hmcts-telephone-numbers" ' +
         'target="_blank">Hello</a>';
       const expectedOutput
         = '<a href="https://www.gov.uk/government/news/scammers-using-hmcts-telephone-numbers" ' +
-        'target="_blank">Hello (opens in new tab)</a>';
+        'target="_blank">Hello<span class=govuk-visually-hidden> - opens in a new tab</span></a>';
 
       expect(warningAppenderFilter(input)).toEqual(expectedOutput);
     });
 
-    test('should add (opens new tab) text to link that contains target="_blank" and other attributes', () => {
+    test('should add hidden "opens in a new tab" text to link that contains target="_blank" plus other attributes', () => {
       const warningAppenderFilter = env.getFilter('warningAppender');
       const input = '<a href="https://www.gov.uk/government/news" target="_blank" rel="noopener">I open in a new tab</a>';
       const expectedOutput
-        = '<a href="https://www.gov.uk/government/news" target="_blank" rel="noopener">I open in a new tab (opens in new tab)</a>';
+        = '<a href="https://www.gov.uk/government/news" target="_blank" rel="noopener">I open in a new tab<span class=govuk-visually-hidden> - opens in a new tab</span></a>';
 
       expect(warningAppenderFilter(input)).toEqual(expectedOutput);
     });
 
-    test.each(['\'_blank\'', '\'_new\''])('should add (opens new tab) text to link text where the target value is wrapped in single quotes', (targetValue) => {
+    test.each(['\'_blank\'', '\'_new\''])('should add hidden "opens in a new tab" text to link text where the target value is wrapped in single quotes', (targetValue) => {
       const warningAppenderFilter = env.getFilter('warningAppender');
       const input = '<a href="https://www.gov.uk/government/news" title="link" target=' + targetValue + ' rel="noopener">I open in a new tab</a>';
       const expectedOutput
-        = '<a href="https://www.gov.uk/government/news" title="link" target=' + targetValue + ' rel="noopener">I open in a new tab (opens in new tab)</a>';
+        = '<a href="https://www.gov.uk/government/news" title="link" target=' + targetValue + ' rel="noopener">I open in a new tab<span class=govuk-visually-hidden> - opens in a new tab</span></a>';
 
       expect(warningAppenderFilter(input)).toEqual(expectedOutput);
     });
 
-    test('should not add (opens in new tab) text when link does not open in a new tab', () => {
+    test('should not add hidden "opens in a new tab" text when link does not open in a new tab', () => {
       const warningAppenderFilter = env.getFilter('warningAppender');
       const input
         = '<a href="https://www.gov.uk/government/news" rel="noopener">I stay in the same tab</a>';
@@ -60,7 +60,7 @@ describe('njkFilters', () => {
       expect(warningAppenderFilter(input)).toEqual(expectedOutput);
     });
 
-    test('should not add (opens in new tab) text when string is not a link', () => {
+    test('should not add hidden "opens in a new tab" text when string is not a link', () => {
       const warningAppenderFilter = env.getFilter('warningAppender');
       const input
         = '<p target="_blank>" This is not a link</p>';
@@ -70,7 +70,7 @@ describe('njkFilters', () => {
       expect(warningAppenderFilter(input)).toEqual(expectedOutput);
     });
 
-    test.each(['"_blank"', '"_new"'])('should add (opens in new tab) to link text ' +
+    test.each(['"_blank"', '"_new"'])('should add hidden "opens in a new tab" to link text ' +
       'when target value is %j and link is surrounded by other text', (targetValue) => {
       const warningAppenderFilter = env.getFilter('warningAppender');
       const input
@@ -78,12 +78,12 @@ describe('njkFilters', () => {
         'rel="noopener" target=' + targetValue + '>Gov UK</a>. It has a lot of stuff to learn about';
       const expectedOutput
         = 'Please make sure to visit this site to learn new information -> <a href="https://www.gov.uk/government/news" ' +
-        'rel="noopener" target=' + targetValue + '>Gov UK (opens in new tab)</a>. It has a lot of stuff to learn about';
+        'rel="noopener" target=' + targetValue + '>Gov UK<span class=govuk-visually-hidden> - opens in a new tab</span></a>. It has a lot of stuff to learn about';
 
       expect(warningAppenderFilter(input)).toEqual(expectedOutput);
     });
 
-    test.each(['"_blank"', '"_new"'])('should add (opens in new tab) to each link text ' +
+    test.each(['"_blank"', '"_new"'])('should add hidden "opens in a new tab" to each link text ' +
       'when there are multiple links that open new tabs', (targetValue) => {
       const warningAppenderFilter = env.getFilter('warningAppender');
       const input
@@ -93,14 +93,14 @@ describe('njkFilters', () => {
         'rel="noopener" target=' + targetValue + '>Gov UK Info</a>';
       const expectedOutput
         = 'Please make sure to visit this site to learn new information -> <a href="https://www.gov.uk/government/news" ' +
-        'rel="noopener" target=' + targetValue + '>Gov UK (opens in new tab)</a>. It has a lot of stuff to learn about. Please also take a ' +
+        'rel="noopener" target=' + targetValue + '>Gov UK<span class=govuk-visually-hidden> - opens in a new tab</span></a>. It has a lot of stuff to learn about. Please also take a ' +
         'look at this site as well <a href="https://www.gov.uk/government/news/information" ' +
-        'rel="noopener" target=' + targetValue + '>Gov UK Info (opens in new tab)</a>';
+        'rel="noopener" target=' + targetValue + '>Gov UK Info<span class=govuk-visually-hidden> - opens in a new tab</span></a>';
 
       expect(warningAppenderFilter(input)).toEqual(expectedOutput);
     });
 
-    test.each(['"_blank"', '"_new"'])('should add (opens in new tab) to link text ' +
+    test.each(['"_blank"', '"_new"'])('should add hidden "opens in a new tab" to link text ' +
       'when link text contains special characters', (targetValue) => {
       const warningAppenderFilter = env.getFilter('warningAppender');
       const input
@@ -108,12 +108,12 @@ describe('njkFilters', () => {
         'rel="noopener" target=' + targetValue + '><strong>Gov<strong> UK &amp;</a>.';
       const expectedOutput
         = '<a href="https://www.gov.uk/government/news" ' +
-        'rel="noopener" target=' + targetValue + '><strong>Gov<strong> UK &amp; (opens in new tab)</a>.';
+        'rel="noopener" target=' + targetValue + '><strong>Gov<strong> UK &amp;<span class=govuk-visually-hidden> - opens in a new tab</span></a>.';
 
       expect(warningAppenderFilter(input)).toEqual(expectedOutput);
     });
 
-    test.each(['"_blank"', '"_new"'])('should add (opens in new tab) to link text ' +
+    test.each(['"_blank"', '"_new"'])('should add hidden "opens in a new tab" to link text ' +
       'even if text already contains a new tab warning', (targetValue) => {
       const warningAppenderFilter = env.getFilter('warningAppender');
       const input
@@ -121,7 +121,7 @@ describe('njkFilters', () => {
         'rel="noopener" target=' + targetValue + '>Gov UK (opens in a new tab)</a>.';
       const expectedOutput
         = '<a href="https://www.gov.uk/government/news" ' +
-        'rel="noopener" target=' + targetValue + '>Gov UK (opens in a new tab) (opens in new tab)</a>.';
+        'rel="noopener" target=' + targetValue + '>Gov UK (opens in a new tab)<span class=govuk-visually-hidden> - opens in a new tab</span></a>.';
 
       expect(warningAppenderFilter(input)).toEqual(expectedOutput);
     });

--- a/src/test/unit/test/modules/nunjucks/njkFilters.ts
+++ b/src/test/unit/test/modules/nunjucks/njkFilters.ts
@@ -12,33 +12,118 @@ describe('njkFilters', () => {
 
   describe('Test the filter that appends warning to links that open new tabs', () => {
     test('should add (opens new tab) text to link that contains target="_blank"', () => {
-      const titleEnhanceFilter = env.getFilter('warningAppender');
+      const warningAppenderFilter = env.getFilter('warningAppender');
       const input = '<a href="https://www.gov.uk/government/news/scammers-using-hmcts-telephone-numbers" ' +
         'target="_blank">Hello</a>';
       const expectedOutput
         = '<a href="https://www.gov.uk/government/news/scammers-using-hmcts-telephone-numbers" ' +
         'target="_blank">Hello (opens in new tab)</a>';
 
-      expect(titleEnhanceFilter(input)).toEqual(expectedOutput);
+      expect(warningAppenderFilter(input)).toEqual(expectedOutput);
     });
 
     test('should add (opens new tab) text to link that contains target="_blank" and other attributes', () => {
-      const titleEnhanceFilter = env.getFilter('warningAppender');
+      const warningAppenderFilter = env.getFilter('warningAppender');
       const input = '<a href="https://www.gov.uk/government/news" target="_blank" rel="noopener">I open in a new tab</a>';
       const expectedOutput
         = '<a href="https://www.gov.uk/government/news" target="_blank" rel="noopener">I open in a new tab (opens in new tab)</a>';
 
-      expect(titleEnhanceFilter(input)).toEqual(expectedOutput);
+      expect(warningAppenderFilter(input)).toEqual(expectedOutput);
     });
 
-    test('should not add (opens new tab) text when link does not open in a new tab', () => {
-      const titleEnhanceFilter = env.getFilter('warningAppender');
+    test.each(['\'_blank\'', '\'_new\''])('should add (opens new tab) text to link text where the target value is wrapped in single quotes', (targetValue) => {
+      const warningAppenderFilter = env.getFilter('warningAppender');
+      const input = '<a href="https://www.gov.uk/government/news" title="link" target=' + targetValue + ' rel="noopener">I open in a new tab</a>';
+      const expectedOutput
+        = '<a href="https://www.gov.uk/government/news" title="link" target=' + targetValue + ' rel="noopener">I open in a new tab (opens in new tab)</a>';
+
+      expect(warningAppenderFilter(input)).toEqual(expectedOutput);
+    });
+
+    test('should not add (opens in new tab) text when link does not open in a new tab', () => {
+      const warningAppenderFilter = env.getFilter('warningAppender');
       const input
         = '<a href="https://www.gov.uk/government/news" rel="noopener">I stay in the same tab</a>';
       const expectedOutput
         = '<a href="https://www.gov.uk/government/news" rel="noopener">I stay in the same tab</a>';
 
-      expect(titleEnhanceFilter(input)).toEqual(expectedOutput);
+      expect(warningAppenderFilter(input)).toEqual(expectedOutput);
+    });
+
+    test('should handle being passed an empty string', () => {
+      const warningAppenderFilter = env.getFilter('warningAppender');
+      const input
+        = '';
+      const expectedOutput
+        = '';
+
+      expect(warningAppenderFilter(input)).toEqual(expectedOutput);
+    });
+
+    test('should not add (opens in new tab) text when string is not a link', () => {
+      const warningAppenderFilter = env.getFilter('warningAppender');
+      const input
+        = '<p target="_blank>" This is not a link</p>';
+      const expectedOutput
+        = '<p target="_blank>" This is not a link</p>';
+
+      expect(warningAppenderFilter(input)).toEqual(expectedOutput);
+    });
+
+    test.each(['"_blank"', '"_new"'])('should add (opens in new tab) to link text ' +
+      'when target value is %j and link is surrounded by other text', (targetValue) => {
+      const warningAppenderFilter = env.getFilter('warningAppender');
+      const input
+        = 'Please make sure to visit this site to learn new information -> <a href="https://www.gov.uk/government/news" ' +
+        'rel="noopener" target=' + targetValue + '>Gov UK</a>. It has a lot of stuff to learn about';
+      const expectedOutput
+        = 'Please make sure to visit this site to learn new information -> <a href="https://www.gov.uk/government/news" ' +
+        'rel="noopener" target=' + targetValue + '>Gov UK (opens in new tab)</a>. It has a lot of stuff to learn about';
+
+      expect(warningAppenderFilter(input)).toEqual(expectedOutput);
+    });
+
+    test.each(['"_blank"', '"_new"'])('should add (opens in new tab) to each link text ' +
+      'when there are multiple links that open new tabs', (targetValue) => {
+      const warningAppenderFilter = env.getFilter('warningAppender');
+      const input
+        = 'Please make sure to visit this site to learn new information -> <a href="https://www.gov.uk/government/news" ' +
+        'rel="noopener" target=' + targetValue + '>Gov UK</a>. It has a lot of stuff to learn about. Please also take a ' +
+        'look at this site as well <a href="https://www.gov.uk/government/news/information" ' +
+        'rel="noopener" target=' + targetValue + '>Gov UK Info</a>';
+      const expectedOutput
+        = 'Please make sure to visit this site to learn new information -> <a href="https://www.gov.uk/government/news" ' +
+        'rel="noopener" target=' + targetValue + '>Gov UK (opens in new tab)</a>. It has a lot of stuff to learn about. Please also take a ' +
+        'look at this site as well <a href="https://www.gov.uk/government/news/information" ' +
+        'rel="noopener" target=' + targetValue + '>Gov UK Info (opens in new tab)</a>';
+
+      expect(warningAppenderFilter(input)).toEqual(expectedOutput);
+    });
+
+    test.each(['"_blank"', '"_new"'])('should add (opens in new tab) to link text ' +
+      'when link text contains special characters', (targetValue) => {
+      const warningAppenderFilter = env.getFilter('warningAppender');
+      const input
+        = '<a href="https://www.gov.uk/government/news" ' +
+        'rel="noopener" target=' + targetValue + '><strong>Gov<strong> UK &amp;</a>.';
+      const expectedOutput
+        = '<a href="https://www.gov.uk/government/news" ' +
+        'rel="noopener" target=' + targetValue + '><strong>Gov<strong> UK &amp; (opens in new tab)</a>.';
+
+      expect(warningAppenderFilter(input)).toEqual(expectedOutput);
+    });
+
+    test.each(['"_blank"', '"_new"'])('should add (opens in new tab) to link text ' +
+      'even if text already contains a new tab warning', (targetValue) => {
+      const warningAppenderFilter = env.getFilter('warningAppender');
+      const input
+        = '<a href="https://www.gov.uk/government/news" ' +
+        'rel="noopener" target=' + targetValue + '>Gov UK (opens in a new tab)</a>.';
+      const expectedOutput
+        = '<a href="https://www.gov.uk/government/news" ' +
+        'rel="noopener" target=' + targetValue + '>Gov UK (opens in a new tab) (opens in new tab)</a>.';
+
+      expect(warningAppenderFilter(input)).toEqual(expectedOutput);
     });
   });
 });

--- a/src/test/unit/test/modules/nunjucks/njkFilters.ts
+++ b/src/test/unit/test/modules/nunjucks/njkFilters.ts
@@ -1,0 +1,44 @@
+import nunjucks from 'nunjucks';
+
+import createFilters from '../../../../../main/modules/nunjucks/njkFilters';
+
+describe('njkFilters', () => {
+  let env: nunjucks.Environment;
+
+  beforeEach(() => {
+    env = new nunjucks.Environment();
+    createFilters(env);
+  });
+
+  describe('Test the filter that appends warning to links that open new tabs', () => {
+    test('should add (opens new tab) text to link that contains target="_blank"', () => {
+      const titleEnhanceFilter = env.getFilter('warningAppender');
+      const input = '<a href="https://www.gov.uk/government/news/scammers-using-hmcts-telephone-numbers" ' +
+        'target="_blank">Hello</a>';
+      const expectedOutput
+        = '<a href="https://www.gov.uk/government/news/scammers-using-hmcts-telephone-numbers" ' +
+        'target="_blank">Hello (opens in new tab)</a>';
+
+      expect(titleEnhanceFilter(input)).toEqual(expectedOutput);
+    });
+
+    test('should add (opens new tab) text to link that contains target="_blank" and other attributes', () => {
+      const titleEnhanceFilter = env.getFilter('warningAppender');
+      const input = '<a href="https://www.gov.uk/government/news" target="_blank" rel="noopener">I open in a new tab</a>';
+      const expectedOutput
+        = '<a href="https://www.gov.uk/government/news" target="_blank" rel="noopener">I open in a new tab (opens in new tab)</a>';
+
+      expect(titleEnhanceFilter(input)).toEqual(expectedOutput);
+    });
+
+    test('should not add (opens new tab) text when link does not open in a new tab', () => {
+      const titleEnhanceFilter = env.getFilter('warningAppender');
+      const input
+        = '<a href="https://www.gov.uk/government/news" rel="noopener">I stay in the same tab</a>';
+      const expectedOutput
+        = '<a href="https://www.gov.uk/government/news" rel="noopener">I stay in the same tab</a>';
+
+      expect(titleEnhanceFilter(input)).toEqual(expectedOutput);
+    });
+  });
+});


### PR DESCRIPTION
### JIRA link ###

https://tools.hmcts.net/jira/browse/FACT-2206

### Change description ###

- Creates a new nunjuck filter that expects a string containing html anchor tags/links and appends a visually hidden '(opens in new tab)' to the link text if it detects a target attribute with a blank/new value. 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
