### PR TITLE
Add Playwright smoke test

### DIFF
--- a/playwright-e2e/tests/smoke/smoke-health.spec.ts
+++ b/playwright-e2e/tests/smoke/smoke-health.spec.ts
@@ -1,0 +1,20 @@
+import { test, expect } from "@playwright/test";
+import http from "http2";
+import { config } from "../../utils/config.utils";
+
+// @smoke
+// Checks that the frontend /health endpoint returns 200 OK and overall service status is UP.
+test.describe("Smoke Test", () => {
+  test("Frontend health endpoint shows all connected services as UP @smoke", async ({
+    request,
+  }) => {
+    const response = await request.get(config.urls.testUrl + "/health", {
+      ignoreHTTPSErrors: true,
+    });
+
+    expect(response.status()).toBe(http.constants.HTTP_STATUS_OK);
+
+    const body = await response.json();
+    expect(body.status).toBe("UP");
+  });
+});


### PR DESCRIPTION
### What
- Added a Playwright smoke test to check the frontend /health endpoint.

### Why
- To ensure core services and frontend health before running further tests.

### Tag
- @smoke

### Notes
- Uses `config.urls.testUrl`
- Includes `ignoreHTTPSErrors` for AAT environment

