### PR TITLE
Add Playwright smoke test for /health endpoint

### DIFF
--- a/src/test/playwright-e2e/tests/smoke/smoke-health.spec.ts
+++ b/src/test/playwright-e2e/tests/smoke/smoke-health.spec.ts
@@ -1,0 +1,19 @@
+import { test, expect } from "@playwright/test";
+import { config } from "../../utils/config.utils";
+
+// @smoke
+// Checks that the frontend /health endpoint returns 200 OK and overall service status is UP.
+test.describe("Smoke Test", () => {
+  test("Frontend health endpoint shows all connected services as UP @smoke", async ({
+    request,
+  }) => {
+    const response = await request.get(config.urls.testUrl + "/health", {
+      ignoreHTTPSErrors: true,
+    });
+
+    expect(response.status()).toBe(200);
+
+    const body = await response.json();
+    expect(body.status).toBe("UP");
+  });
+});

--- a/src/test/playwright-e2e/tests/smoke/smoke-health.spec.ts
+++ b/src/test/playwright-e2e/tests/smoke/smoke-health.spec.ts
@@ -1,7 +1,6 @@
 import { test, expect } from "@playwright/test";
 import { config } from "../../utils/config.utils";
 
-// @smoke
 // Checks that the frontend /health endpoint returns 200 OK and overall service status is UP.
 test.describe("Smoke Test", () => {
   test("Frontend health endpoint shows all connected services as UP @smoke", async ({


### PR DESCRIPTION
### What
- Added a Playwright smoke test to check the frontend /health endpoint.

### Why
- To ensure core services and frontend health before running further tests.

### Tag
- @smoke

### Notes
- Uses `config.urls.testUrl`
- Includes `ignoreHTTPSErrors` for AAT environment
