### PR TITLE
Update Jenkinsfile to enable security scan

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -17,6 +17,8 @@ withNightlyPipeline(type, product, component) {
   before('fullFunctionalTest') {
     yarnBuilder.yarn('playwright install')
   }
+
+  enableSecurityScan()
 //  enableFortifyScan()
 //
 //  afterSuccess('fortify-scan') {


### PR DESCRIPTION
#959 Enable security scan in nightly Jenkins pipeline.

This is to help the CoE with a Proof of Value into DAST scanning. I am comparing results from OWASP ZAP to Fortify DAST.

This service is ideal for the PoV as it does not rely on any authentication (IDAM etc) to use the service, all pages are public-facing, so no additional configuration is required.